### PR TITLE
fix(publish): invert dry-run condition to enable CI publishing

### DIFF
--- a/.mise/tasks/publish
+++ b/.mise/tasks/publish
@@ -26,11 +26,13 @@ if [ "${usage_tag}" = "next" ]; then
 	CURRENT_VERSION=$(jq -r '.version' package.json)
 	PRERELEASE_VERSION="$(semver get release "$CURRENT_VERSION")-next.${BUILD_NUMBER}"
 	echo " > bumping version: ${CURRENT_VERSION} -> ${PRERELEASE_VERSION}"
+
+	if [ "${usage_dry_run}" != true ]; then
+		npm version "${PRERELEASE_VERSION}" --no-git-tag-version --allow-same-version
+	fi
 fi
 
-if [ "${usage_dry_run}" = true ]; then
-	npm version "${PRERELEASE_VERSION}" --no-git-tag-version --allow-same-version
-
+if [ "${usage_dry_run}" != true ]; then
 	# Determine if we should use provenance
 	# Only enable in CI environments with OIDC support
 	PROVENANCE_FLAG=""
@@ -49,4 +51,6 @@ if [ "${usage_dry_run}" = true ]; then
 		--tag "${usage_tag}" \
 		$PROVENANCE_FLAG
 	echo "Published successfully!"
+else
+	echo "Dry run mode - skipping actual publish"
 fi


### PR DESCRIPTION
## Summary
Fixes the inverted dry-run condition that prevented actual publishing in CI environments.

## Problem
The publish task had an inverted condition (`if [ "${usage_dry_run}" = true ]`) which meant:
- Publishing logic **only** ran during dry-runs (when no actual publish should happen)
- During real CI publishes, the script did nothing - no version bumping, no npm publish

## Solution
- Inverted the condition to `if [ "${usage_dry_run}" != true ]` 
- Now publishes correctly when not in dry-run mode
- Prerelease version bumping only applies for the 'next' tag
- Added dry-run feedback message

## Changes
- Fixed inverted dry-run logic in .mise/tasks/publish
- Corrected version bumping to only happen for 'next' tag publishes
- Added clear messaging for dry-run behavior

## Testing
This fix addresses the 403 Forbidden error from npm when attempting to publish version 1.0.0-next.1, which should now properly increment to 1.0.0-next.2 on subsequent publishes.